### PR TITLE
Hook into _canShowMarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ guide the learner’s interaction with the component.
 
 **_canShowModelAnswer** (boolean): Setting this to `false` prevents the [**_showCorrectAnswer** button](https://github.com/adaptlearning/adapt_framework/wiki/Core-Buttons) from being displayed. The default is `true`.
 
+**_canShowMarking** (boolean): Setting this to `false` prevents ticks and crosses being displayed on question completion. The default is `true`.
+
 **_recordInteraction** (boolean) Determines whether or not the learner's answers will be recorded to the LMS via cmi.interactions. Default is `true`. For further information, see the entry for `_shouldRecordInteractions` in the README for [adapt-contrib-spoor](https://github.com/adaptlearning/adapt-contrib-spoor).
 
 **placeholder** (string): This is the text that is initially displayed on each drop-down. It is usually set to something like 'Please select an option'.  

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-matching",
   "version": "2.0.4",
-  "framework": "^2.0.0",
+  "framework": "^2.0.11",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-matching",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-matching%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",
   "description": "A question component that allows the learner to match the options to question stems",

--- a/example.json
+++ b/example.json
@@ -9,6 +9,7 @@
     "_shouldDisplayAttempts": false,
     "_isRandom": true,
     "_canShowModelAnswer": true,
+    "_canShowMarking": true,
     "_recordInteraction": true,
     "_questionWeight": 10,
     "title": "Matching",

--- a/js/adapt-contrib-matching.js
+++ b/js/adapt-contrib-matching.js
@@ -168,6 +168,7 @@ define(function(require) {
         // This is important and should give the user feedback on how they answered the question
         // Normally done through ticks and crosses by adding classes
         showMarking: function() {
+            if (!this.model.get('_canShowMarking')) return;
 
             _.each(this.model.get('_items'), function(item, i) {
 

--- a/less/matching.less
+++ b/less/matching.less
@@ -112,7 +112,8 @@
 			.matching-select-icon {
 				display: none;
 			}
-			.matching-correct-icon {
+			.incorrect .matching-correct-icon,
+			.correct .matching-correct-icon {
 				display: block;
 			}
 		}

--- a/properties.schema
+++ b/properties.schema
@@ -48,6 +48,14 @@
       "validators": [],
       "help": "Select 'true' to allow the user to view the 'model answer' should they answer the question incorrectly"
     },
+    "_canShowMarking": {
+      "type": "boolean",
+      "default": true,
+      "title": "Display Marking",
+      "inputType": { "type": "Boolean", "options": [ true, false ] },
+      "validators": [],
+      "help": "Select 'true' to display ticks and crosses on question completion"
+    },
     "_shouldDisplayAttempts": {
       "type":"boolean",
       "required":false,

--- a/templates/matching.hbs
+++ b/templates/matching.hbs
@@ -3,7 +3,7 @@
   {{> component this}}
   <div class="matching-widget component-widget {{#unless _isEnabled}} disabled {{#if _isInteractionComplete}} complete submitted show-user-answer {{#if _isCorrect}}correct{{/if}} {{/if}} {{/unless}}">
     {{#each _items}}
-    <div class="matching-item item {{#unless ../_isEnabled}} {{#if _isCorrect}}correct{{else}}incorrect{{/if}} {{/unless}} item-{{@index}}">
+    <div class="matching-item item {{#unless ../_isEnabled}}{{#if ../_canShowMarking}}{{#if _isCorrect}}correct{{else}}incorrect{{/if}}{{/if}}{{/unless}} item-{{@index}}">
       <div class="matching-item-title">{{{a11y_text text}}}</div>
       <div class="matching-select-container component-item-color">
         <div class="matching-select-state">


### PR DESCRIPTION
Avoids adding correctness classes to items if `_canShowMarking` is false.

Please only merge once the new version of the framework has been released (v2.0.11).

Original issue: adaptlearning/adapt_framework#1046.