### PR TITLE
ensure leading/trailing spaces are stripped from option text

### DIFF
--- a/js/adapt-contrib-matching.js
+++ b/js/adapt-contrib-matching.js
@@ -249,6 +249,7 @@ define([
         },
 
         selectValue: function(i, value) {
+            value = $.trim(value);// select2 strips leading/trailing spaces so we need to as well - fixes https://github.com/adaptlearning/adapt_framework/issues/1503
             this.$('select').eq(i).val(value).trigger('change');
         },
 


### PR DESCRIPTION
during `selectValue`, fixes [1503](https://github.com/adaptlearning/adapt_framework/issues/1503)