### PR TITLE
issue/1889: drop down appears above page bottom

### DIFF
--- a/js/adapt-contrib-matching.js
+++ b/js/adapt-contrib-matching.js
@@ -15,6 +15,71 @@ define([
         "select2/dropdown/closeOnSelect"
     ], function(Utils, DropdownAdapter, AttachContainer, CloseOnSelect) {
 
+        // code added to make dropdown sit above body bottom where appropriate
+        AttachContainer.prototype.bind = function(decorated, container, $container) {
+
+            var self = this;
+            decorated.call(this, $container, $container);
+
+            container.on('open', function () {
+                setTimeout(function() {
+                    self.position(self.$dropdown, $container);
+                }, 0);
+            });
+
+        };
+
+        AttachContainer.prototype.position = function(decorated, $dropdown, $container) {
+
+            var $dropdownContainer = $container.find('.dropdown-wrapper');
+            $dropdownContainer.append($dropdown);
+
+            var $window = $(window);
+
+            var viewport = {
+              top: $window.scrollTop(),
+              bottom: $window.scrollTop() + $window.height()
+            };
+
+            var container = $container.offset();
+            container.height = $container.outerHeight(false);
+            container.bottom = container.top + container.height;
+
+            var dropdown = {
+              height: $dropdown.outerHeight(false)
+            };
+
+            var viewport = {
+              top: $window.scrollTop(),
+              bottom: $window.scrollTop() + $window.height()
+            };
+
+            var enoughRoomBelow = !dropdown.height || viewport.bottom > (container.bottom + dropdown.height);
+
+            var oldDirection = $dropdown.hasClass('select2-dropdown--above') ? "above" : $dropdown.hasClass('select2-dropdown--below') ? "below" : "none";
+            var newDirection = !enoughRoomBelow ? "above" : "below";
+
+            if (newDirection === oldDirection) return;
+
+            $dropdown
+                .removeClass('select2-dropdown--below select2-dropdown--above')
+                .addClass('select2-dropdown--' + newDirection);
+            $container
+                .removeClass('select2-container--below select2-container--above')
+                .addClass('select2-container--' + newDirection);
+
+            switch (newDirection) {
+                case "below":
+                    $dropdown.css("bottom", "");
+                    break;
+                case "above":
+                    $dropdown.css("bottom", container.height);
+                    break;
+            }
+
+        };
+
+        // override default AttachBody
         dropdownAdapter = Utils.Decorate(
             Utils.Decorate(
                 DropdownAdapter,

--- a/js/adapt-contrib-matching.js
+++ b/js/adapt-contrib-matching.js
@@ -49,8 +49,8 @@ define([
             var $window = $(window);
 
             var viewport = {
-              top: $window.scrollTop(),
-              bottom: $window.scrollTop() + $window.height()
+                top: $window.scrollTop(),
+                bottom: $window.scrollTop() + $window.height()
             };
 
             var container = $container.offset();
@@ -58,12 +58,12 @@ define([
             container.bottom = container.top + container.height;
 
             var dropdown = {
-              height: $dropdown.outerHeight(false)
+                height: $dropdown.outerHeight(false)
             };
 
             var viewport = {
-              top: $window.scrollTop(),
-              bottom: $window.scrollTop() + $window.height()
+                top: $window.scrollTop(),
+                bottom: $window.scrollTop() + $window.height()
             };
 
             var enoughRoomBelow = !dropdown.height || viewport.bottom > (container.bottom + dropdown.height);

--- a/js/adapt-contrib-matching.js
+++ b/js/adapt-contrib-matching.js
@@ -15,7 +15,10 @@ define([
         "select2/dropdown/closeOnSelect"
     ], function(Utils, DropdownAdapter, AttachContainer, CloseOnSelect) {
 
-        // code added to make dropdown sit above body bottom where appropriate
+        /*
+         * issues/1889: fix from https://github.com/adaptlearning/adapt_framework/issues/1889
+         * code added to make dropdown sit above body bottom where appropriate
+         */ 
         AttachContainer.prototype.bind = function(decorated, container, $container) {
 
             var self = this;

--- a/js/adapt-contrib-matching.js
+++ b/js/adapt-contrib-matching.js
@@ -21,18 +21,28 @@ define([
             var self = this;
             decorated.call(this, $container, $container);
 
+            container.on('opening', function () {
+                // hide so that popup doesn't jump when repositioned
+                self.$dropdown.css("visibility", "hidden");
+            });
+
             container.on('open', function () {
+                // add dropdown at this point so that the browser focus works correctly
+                var $dropdownContainer = $container.find('.dropdown-wrapper');
+                $dropdownContainer.append(self.$dropdown);
+
+                // defer to allow dom to settle before repositioning
                 setTimeout(function() {
                     self.position(self.$dropdown, $container);
+                    self.$dropdown.css("visibility", "");
                 }, 0);
+                
             });
 
         };
 
         AttachContainer.prototype.position = function(decorated, $dropdown, $container) {
-            var $dropdownContainer = $container.find('.dropdown-wrapper');
-            $dropdownContainer.append($dropdown);
-            
+
             var $window = $(window);
 
             var viewport = {
@@ -77,6 +87,7 @@ define([
             }
 
         };
+
 
         // override default AttachBody
         dropdownAdapter = Utils.Decorate(

--- a/js/adapt-contrib-matching.js
+++ b/js/adapt-contrib-matching.js
@@ -61,11 +61,6 @@ define([
                 height: $dropdown.outerHeight(false)
             };
 
-            var viewport = {
-                top: $window.scrollTop(),
-                bottom: $window.scrollTop() + $window.height()
-            };
-
             var enoughRoomBelow = !dropdown.height || viewport.bottom > (container.bottom + dropdown.height);
 
             var oldDirection = $dropdown.hasClass('select2-dropdown--above') ? "above" : $dropdown.hasClass('select2-dropdown--below') ? "below" : "none";

--- a/js/adapt-contrib-matching.js
+++ b/js/adapt-contrib-matching.js
@@ -30,7 +30,9 @@ define([
         };
 
         AttachContainer.prototype.position = function(decorated, $dropdown, $container) {
-
+            var $dropdownContainer = $container.find('.dropdown-wrapper');
+            $dropdownContainer.append($dropdown);
+            
             var $window = $(window);
 
             var viewport = {

--- a/js/adapt-contrib-matching.js
+++ b/js/adapt-contrib-matching.js
@@ -31,9 +31,6 @@ define([
 
         AttachContainer.prototype.position = function(decorated, $dropdown, $container) {
 
-            var $dropdownContainer = $container.find('.dropdown-wrapper');
-            $dropdownContainer.append($dropdown);
-
             var $window = $(window);
 
             var viewport = {


### PR DESCRIPTION
https://github.com/adaptlearning/adapt_framework/issues/1889

### To reproduce
1. Add a matching to the bottom of a scrolling page or before a trickle.
2. Add enough options to the last dropdown in the matching, so that it will run off the page - 5/6 options should do.
3. Scroll down to the matching and open the last dropdown

### Outcomes
With the fix: The dropdown will appear above the control flowing upwards
Without the fix: The dropdown will appear beneath the control, flowing off the screen