### PR TITLE
issue/2459 force disabled old ios fixes in framework once installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ contains values for three types of answers: **correct**, **_incorrect**, and **_
 No known limitations.
 
 ----------------------------
-**Version number:**  3.0.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  3.0.1   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
 **Framework versions:** 2.0.16+  
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-matching/graphs/contributors)  
 **Accessibility support:** WAI AA   

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-matching",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "framework": ">=2.0.16",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-matching",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/js/adapt-contrib-matching.js
+++ b/js/adapt-contrib-matching.js
@@ -4,6 +4,12 @@ define([
     './matchingModel'
 ], function(Adapt, MatchingView, MatchingModel) {
 
+    // Force disable old iOS fixes in v2 frameworks
+    // https://github.com/adaptlearning/adapt_framework/issues/2459
+    if ($.a11y && $.a11y.options && $.a11y.options.isIOSFixesEnabled) {
+        $.a11y.options.isIOSFixesEnabled = false;
+    }
+
     return Adapt.register("matching", {
         view: MatchingView,
         model: MatchingModel


### PR DESCRIPTION
[#2459](https://github.com/adaptlearning/adapt_framework/issues/2459)
* Force disable old ios click fixes which are no longer necessary