### PR TITLE
remove code that was only needed for backwards-compatibility

### DIFF
--- a/js/adapt-contrib-matching.js
+++ b/js/adapt-contrib-matching.js
@@ -4,13 +4,7 @@ define([
   './matchingModel'
 ], function(Adapt, MatchingView, MatchingModel) {
 
-  // Force disable old iOS fixes in v2 frameworks
-  // https://github.com/adaptlearning/adapt_framework/issues/2459
-  if ($.a11y && $.a11y.options && $.a11y.options.isIOSFixesEnabled) {
-    $.a11y.options.isIOSFixesEnabled = false;
-  }
-
-  return Adapt.register("matching", {
+  return Adapt.register('matching', {
     view: MatchingView,
     model: MatchingModel
   });


### PR DESCRIPTION
this component is no longer compatible with older versions of the Adapt Framework, making this code redundant

resolves https://github.com/adaptlearning/adapt_framework/issues/2584