### PR TITLE
Fix: Add correct +/ incorrect aria labels to ticks and crosses (fixes #154)

### DIFF
--- a/templates/matching.jsx
+++ b/templates/matching.jsx
@@ -1,10 +1,7 @@
-import Adapt from 'core/js/adapt';
 import React from 'react';
 import { templates, classes } from 'core/js/reactHelpers';
 
 export default function Matching(props) {
-  const ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
-
   const {
     _isEnabled,
     _isInteractionComplete,
@@ -12,7 +9,8 @@ export default function Matching(props) {
     _shouldShowMarking,
     _isCorrectAnswerShown,
     _items,
-    _options
+    _options,
+    _globals
   } = props;
 
   const displayAsCorrect = (_isInteractionComplete && (_isCorrectAnswerShown || _isCorrect));
@@ -56,10 +54,10 @@ export default function Matching(props) {
                 <templates.matchingDropDown {...props} _itemIndex={_index} />
 
                 <div className="matching-item__select-state">
-                  <div className="matching-item__select-icon matching-item__select-correct-icon" aria-label={ariaLabels.correct}>
+                  <div className="matching-item__select-icon matching-item__select-correct-icon" aria-label={_globals._accessibility._ariaLabels.correct}>
                     <div className="icon"></div>
                   </div>
-                  <div className="matching-item__select-icon matching-item__select-incorrect-icon" aria-label={ariaLabels.incorrect}>
+                  <div className="matching-item__select-icon matching-item__select-incorrect-icon" aria-label={_globals._accessibility._ariaLabels.incorrect}>
                     <div className="icon"></div>
                   </div>
                 </div>

--- a/templates/matching.jsx
+++ b/templates/matching.jsx
@@ -1,7 +1,10 @@
+import Adapt from 'core/js/adapt';
 import React from 'react';
 import { templates, classes } from 'core/js/reactHelpers';
 
 export default function Matching(props) {
+  const ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
+
   const {
     _isEnabled,
     _isInteractionComplete,
@@ -53,10 +56,10 @@ export default function Matching(props) {
                 <templates.matchingDropDown {...props} _itemIndex={_index} />
 
                 <div className="matching-item__select-state">
-                  <div className="matching-item__select-icon matching-item__select-correct-icon">
+                  <div className="matching-item__select-icon matching-item__select-correct-icon" aria-label={ariaLabels.correct}>
                     <div className="icon"></div>
                   </div>
-                  <div className="matching-item__select-icon matching-item__select-incorrect-icon">
+                  <div className="matching-item__select-icon matching-item__select-incorrect-icon" aria-label={ariaLabels.incorrect}>
                     <div className="icon"></div>
                   </div>
                 </div>


### PR DESCRIPTION
Fixes #154 

### Fix
Adds aria-labels of Correct or Incorrect to the tick and cross icons

### Testing
1. Complete a Matching component with a mix of correct and incorrect responses
2. Toggle between Show Correct Answer and Show My Answer
3. With a screenreader, tab up to where each answer is shown and then to the tick/cross icon.

Relates to https://github.com/adaptlearning/adapt_framework/issues/2241

