### PR TITLE
Fix: u-no-select class added to dropdown item text (fixes #161)

### DIFF
--- a/templates/matchingDropDown.jsx
+++ b/templates/matchingDropDown.jsx
@@ -225,7 +225,7 @@ export default function MatchingDropDown(props) {
             selected={_isHighlighted || null}
             onClick={onOptionClicked}
           >
-            <div className="dropdown-item__inner js-dropdown-list-item-inner" dangerouslySetInnerHTML={{ __html: displayText || text }}>
+            <div className="dropdown-item__inner js-dropdown-list-item-inner u-no-select" dangerouslySetInnerHTML={{ __html: displayText || text }}>
             </div>
           </li>;
         })}


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #161 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* u-no-select class added to dropdown item text #161 

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Attempt to click and drag over item text
2. Ensure text can't be highlighted and instead item is selected as expected

[//]: # (Mention any other dependencies)


