### PR TITLE
Fix: compile item text (fixes #173)

### DIFF
--- a/templates/matching.jsx
+++ b/templates/matching.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { templates, classes } from 'core/js/reactHelpers';
+import { templates, classes, compile } from 'core/js/reactHelpers';
 
 export default function Matching(props) {
   const {
@@ -53,7 +53,7 @@ export default function Matching(props) {
 
               {text &&
               <div className="matching-item__title">
-                <div className="matching-item__title_inner" dangerouslySetInnerHTML={{ __html: text }}>
+                <div className="matching-item__title_inner" dangerouslySetInnerHTML={{ __html: compile(text) }}>
                 </div>
               </div>
               }

--- a/templates/matchingDropDown.jsx
+++ b/templates/matchingDropDown.jsx
@@ -224,7 +224,7 @@ export default function MatchingDropDown(props) {
             selected={_isHighlighted || null}
             onClick={onOptionClicked}
           >
-            <div className="dropdown-item__inner js-dropdown-list-item-inner u-no-select" dangerouslySetInnerHTML={{ __html: displayText || text }}>
+            <div className="dropdown-item__inner js-dropdown-list-item-inner u-no-select" dangerouslySetInnerHTML={{ __html: displayText || compile(text) }}>
             </div>
           </li>;
         })}

--- a/templates/matchingDropDown.jsx
+++ b/templates/matchingDropDown.jsx
@@ -219,7 +219,6 @@ export default function MatchingDropDown(props) {
             id={`dropdown__item__${_id}__${_itemIndex}__${_index}`}
             className="dropdown-item js-dropdown-list-item"
             role="option"
-            text={text}
             value={_index}
             aria-selected={_isHighlighted || null}
             selected={_isHighlighted || null}


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-matching/issues/173

To support the use of [a11y_alt_text](https://github.com/adaptlearning/adapt-contrib-core/commit/a92c7ffdb431bdf126e080c009b3b9c324642755) helper tag.

## PR Test
Add `a11y_alt_text` helper to Matching item `text` e.g. `{{a11y_alt_text '$5bn' 'five billion dollars'}}`.

In your course, go to the Matching item and '$5bn' should be displayed.

Using the browser devtools, inspect '$5bn' and the helper should have split out the on screen text and a11y text e.g.
`<span aria-hidden="true">$5bn</span><span class="aria-label">five billion dollars</span>`

