### PR TITLE
Update: Remove ariaQuestion placeholder text (fixes #175)

### DIFF
--- a/example.json
+++ b/example.json
@@ -9,7 +9,7 @@
         "displayTitle": "Matching",
         "body": "Basically what you need to do is match the questions below with the drop down box option.",
         "instruction": "Choose an option from each dropdown list and select Submit.",
-        "ariaQuestion": "Question text specifically for screen readers.",
+        "ariaQuestion": "",
         "_attempts": 1,
         "_shouldDisplayAttempts": false,
         "_shouldResetAllAnswers": false,


### PR DESCRIPTION
Prevent placeholder text being copied over and left in accessible courses. Property description is noted in README and schema help/description for reference.

Fixes https://github.com/adaptlearning/adapt-contrib-matching/issues/175

Missing `ariaQuestion` property added to [wiki](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes/_edit#question-model-attributes).