### PR TITLE
New: Add "is-selected" class if an option has been selected (fixes #178)

### DIFF
--- a/templates/matchingDropDown.jsx
+++ b/templates/matchingDropDown.jsx
@@ -171,7 +171,8 @@ export default function MatchingDropDown(props) {
         disabled={!_isEnabled}
         className={classes([
           'dropdown__btn js-dropdown-btn',
-          !_isEnabled && 'is-disabled'
+          !_isEnabled && 'is-disabled',
+          (displayActiveOption.text !== placeholder) && 'is-selected'
         ])}
         aria-haspopup="listbox"
         aria-expanded={isOpen}


### PR DESCRIPTION
Fix #178 

### Fix
* Adds an `is-selected` class if an option has been selected

### Testing
1. Set up a Matching component with at least two options
2. Select an option for only one of them
3. Ensure that the selected `.dropdown__btn` element has the `is-selected` class and the other does not.

### Caveats
If the placeholder text is the same as an option's text, the `is-selected` class will not be applied when the option is selected.