### PR TITLE
Fix: Add missing properties _allowOnlyUniqueAnswers and _hasItemScoring (fixes #183)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ guide the learner’s interaction with the component.
 
 **placeholder** (string): This is the text that is initially displayed on each drop-down. It is usually set to something like 'Please select an option'.
 
+**\_allowOnlyUniqueAnswers** (boolean): When set to `false`, multiple items can be selected with the same option text. Defaults to `false`.
+
+**\_hasItemScoring** (boolean): When set to `false`, this question scores 0 for incorrect and 'Question Weight' for correct. When enabled, this question scores by summing the scores of the selected options. Defaults to `false`.
+
 **\_items** (array): Multiple items may be created. Each *item* represents one question and its possible answers. It contains values for **text** and multiple **\_options**.
 
 >**text** (string): Text that functions as the question.
@@ -103,15 +107,17 @@ contains values for three types of answers: **correct**, **\_incorrect**, and **
 When **Matching** is used with Adapt Framework v5.12.0 (or better), it supports announcing the correct/learner answer to screen readers (via an an [ARIA Live Region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)) when the Correct Answer button is toggled by the learner. The following attributes are used to provide this functionality: **ariaCorrectAnswer**, **ariaUserAnswer**.
 
 These ARIA labels are not visible elements; they are used by assistive technology (such as screen readers). Should any of these labels need to be customised or translated, they can be found within the `_globals._components._matching` object in **course.json** (or Project settings > Globals in the Adapt Authoring Tool).
-<div float align=right><a href="#top">Back to Top</a></div>
 
 ## Limitations
 
 No known limitations.
 
+<div float align=right><a href="#top">Back to Top</a></div>
+
 -----------------------------
+
 <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>
-**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-matching/graphs/contributors)
-**Accessibility support:** WAI AA
-**RTL support:** Yes
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 14 for macOS/iOS/iPadOS, Opera
+**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-matching/graphs/contributors)<br>
+**Accessibility support:** WAI AA<br>
+**RTL support:** Yes<br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, Safari for macOS/iOS/iPadOS, Opera<br>

--- a/properties.schema
+++ b/properties.schema
@@ -140,7 +140,7 @@
             "title": "Record interaction",
             "inputType": "Checkbox",
             "validators": [],
-            "help": "If disabled, recording the user's answer(s) to this question to cmi.interactions on the LMS will be disabled for this component only."
+            "help": "If disabled, recording the user's answer(s) to this question to cmi.interactions on the LMS will be disabled for this component only. Defaults to true"
         },
         "_hasItemScoring": {
             "type": "boolean",
@@ -149,7 +149,7 @@
             "title": "Enable item scoring",
             "inputType": "Checkbox",
             "validators": [],
-            "help": "When disabled, this question scores 0 for incorrect and 'Question Weight' for correct. When enabled, this question scores by summing the scores of the selected options."
+            "help": "When disabled, this question scores 0 for incorrect and 'Question Weight' for correct. When enabled, this question scores by summing the scores of the selected options. Defaults to false"
         },
         "_allowOnlyUniqueAnswers": {
             "type": "boolean",
@@ -158,7 +158,7 @@
             "title": "Unique answers only",
             "inputType": "Checkbox",
             "validators": [],
-            "help": "When disabled, multiple items can be selected with the same option text."
+            "help": "When disabled, multiple items can be selected with the same option text. Defaults to false"
         },
         "placeholder": {
             "type": "string",

--- a/properties.schema
+++ b/properties.schema
@@ -140,7 +140,7 @@
             "title": "Record interaction",
             "inputType": "Checkbox",
             "validators": [],
-            "help": "If disabled, recording the user's answer(s) to this question to cmi.interactions on the LMS will be disabled for this component only. Defaults to true"
+            "help": "If disabled, recording the user's answer(s) to this question to cmi.interactions on the LMS will be disabled for this component only. Defaults to true."
         },
         "_hasItemScoring": {
             "type": "boolean",
@@ -149,7 +149,7 @@
             "title": "Enable item scoring",
             "inputType": "Checkbox",
             "validators": [],
-            "help": "When disabled, this question scores 0 for incorrect and 'Question Weight' for correct. When enabled, this question scores by summing the scores of the selected options. Defaults to false"
+            "help": "When disabled, this question scores 0 for incorrect and 'Question Weight' for correct. When enabled, this question scores by summing the scores of the selected options. Defaults to false."
         },
         "_allowOnlyUniqueAnswers": {
             "type": "boolean",
@@ -158,7 +158,7 @@
             "title": "Unique answers only",
             "inputType": "Checkbox",
             "validators": [],
-            "help": "When disabled, multiple items can be selected with the same option text. Defaults to false"
+            "help": "When disabled, multiple items can be selected with the same option text. Defaults to false."
         },
         "placeholder": {
             "type": "string",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -200,7 +200,7 @@
                 "final": {
                   "type": "string",
                   "title": "Default incorrect feedback",
-                  "description": "Incorrect answer feedback for the final attempt.",
+                  "description": "Incorrect answer feedback for the final attempt",
                   "default": "",
                   "_adapt": {
                     "translatable": true

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -45,13 +45,13 @@
         "_attempts": {
           "type": "number",
           "title": "Allowed attempts",
-          "description": "How many attempts the learner is allowed",
+          "description": "How many attempts the learner is allowed. Defaults to `1` attempt",
           "default": 1
         },
         "_canShowModelAnswer": {
           "type": "boolean",
           "title": "Enable correct answer toggle",
-          "description": "Allow the user to view the 'model answer' if they answer the question incorrectly",
+          "description": "Allow the user to view the 'model answer' if they answer the question incorrectly. Defaults to true",
           "default": true
         },
         "_canShowFeedback": {
@@ -67,7 +67,7 @@
         "_shouldResetAllAnswers": {
           "type": "boolean",
           "title": "Reset correct answers between attempts",
-          "description": "Controls whether all - or just incorrect - answers should be reset when the question is reset",
+          "description": "Controls whether all - or just incorrect - answers should be reset when the question is reset. Defaults to true",
           "default": true
         },
         "_shouldDisplayAttempts": {
@@ -94,7 +94,7 @@
         "_recordInteraction": {
           "type": "boolean",
           "title": "Record interaction",
-          "description": "If disabled, recording the user's answer(s) to this question to cmi.interactions on the LMS will be disabled for this component only",
+          "description": "If disabled, recording the user's answer(s) to this question to cmi.interactions on the LMS will be disabled for this component only. Defaults to true",
           "default": true
         },
         "placeholder": {
@@ -105,6 +105,18 @@
           "_adapt": {
             "translatable": true
           }
+        },
+        "_hasItemScoring": {
+          "type": "boolean",
+          "title": "Enable item scoring",
+          "description": "When disabled, this question scores 0 for incorrect and 'Question Weight' for correct. When enabled, this question scores by summing the scores of the selected options. Defaults to false.",
+          "default": false
+        },
+        "_allowOnlyUniqueAnswers": {
+          "type": "boolean",
+          "title": "Unique answers only",
+          "description": "When disabled, multiple items can be selected with the same option text. Defaults to false.",
+          "default": false
         },
         "_items": {
           "type": "array",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -45,13 +45,13 @@
         "_attempts": {
           "type": "number",
           "title": "Allowed attempts",
-          "description": "How many attempts the learner is allowed. Defaults to `1` attempt",
+          "description": "How many attempts the learner is allowed. Defaults to `1` attempt.",
           "default": 1
         },
         "_canShowModelAnswer": {
           "type": "boolean",
           "title": "Enable correct answer toggle",
-          "description": "Allow the user to view the 'model answer' if they answer the question incorrectly. Defaults to true",
+          "description": "Allow the user to view the 'model answer' if they answer the question incorrectly. Defaults to true.",
           "default": true
         },
         "_canShowFeedback": {
@@ -67,7 +67,7 @@
         "_shouldResetAllAnswers": {
           "type": "boolean",
           "title": "Reset correct answers between attempts",
-          "description": "Controls whether all - or just incorrect - answers should be reset when the question is reset. Defaults to true",
+          "description": "Controls whether all - or just incorrect - answers should be reset when the question is reset. Defaults to true.",
           "default": true
         },
         "_shouldDisplayAttempts": {
@@ -94,7 +94,7 @@
         "_recordInteraction": {
           "type": "boolean",
           "title": "Record interaction",
-          "description": "If disabled, recording the user's answer(s) to this question to cmi.interactions on the LMS will be disabled for this component only. Defaults to true",
+          "description": "If disabled, recording the user's answer(s) to this question to cmi.interactions on the LMS will be disabled for this component only. Defaults to true.",
           "default": true
         },
         "placeholder": {
@@ -200,7 +200,7 @@
                 "final": {
                   "type": "string",
                   "title": "Default incorrect feedback",
-                  "description": "Incorrect answer feedback for the final attempt",
+                  "description": "Incorrect answer feedback for the final attempt.",
                   "default": "",
                   "_adapt": {
                     "translatable": true


### PR DESCRIPTION
Fixes #183 

### Fix
* Adds missing properties `_allowOnlyUniqueAnswers` and `_hasItemScoring` to _README.md_ and V1 schemas.
* Minor updates to documentation and help text