### PR TITLE
Fix: restore dropdown btn focus outline (fixes #194)

### DIFF
--- a/less/dropdown.less
+++ b/less/dropdown.less
@@ -1,7 +1,6 @@
 .dropdown {
   &__btn {
     width: 100%;
-    outline: 0;
   }
 
   &__btn.is-disabled &__icon {


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-matching/issues/194

### Fix
* Focus outline should inherit from browser/OS for consistency with other focusable elements in Adapt. PR removes the outline style that prevents this.



