### PR TITLE
New: Added support for _canShowCorrectness

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ guide the learner’s interaction with the component.
 
 **\_canShowModelAnswer** (boolean): Setting this to `false` prevents the [**\_showCorrectAnswer** button](https://github.com/adaptlearning/adapt_framework/wiki/Core-Buttons) from being displayed. The default is `true`.
 
+**\_canShowCorrectness** (boolean): Setting this to `true` replaces the associated `_canShowModelAnswer` toggle button and a comma separated list of correct options is displayed below the submitted item. The default is `false`.
+
 **\_canShowFeedback** (boolean): Setting this to `false` disables feedback, so it is not shown to the user. The default is `true`.
 
 **\_canShowMarking** (boolean): Setting this to `false` prevents ticks and crosses being displayed on question completion. The default is `true`.

--- a/example.json
+++ b/example.json
@@ -17,6 +17,7 @@
         "_isRandomQuestionOrder": false,
         "_questionWeight": 1,
         "_canShowModelAnswer": true,
+        "_canShowCorrectness": false,
         "_canShowFeedback": true,
         "_canShowMarking": true,
         "_recordInteraction": true,

--- a/js/MatchingModel.js
+++ b/js/MatchingModel.js
@@ -27,6 +27,15 @@ export default class MatchingModel extends ItemsQuestionModel {
       options.push(...itemOptions);
       return options;
     }, []);
+    items.forEach(item => {
+      const itemOptions = (item._options || []);
+      item._correctAnswers = itemOptions
+        .filter(option => option._isCorrect)
+        .map(option => option.text || '')
+        .map(item => item.trim())
+        .filter(Boolean)
+        .join(', ');
+    });
     this.set({
       _items: items,
       _selectable: items.length

--- a/js/MatchingModel.js
+++ b/js/MatchingModel.js
@@ -33,8 +33,7 @@ export default class MatchingModel extends ItemsQuestionModel {
         .filter(option => option._isCorrect)
         .map(option => option.text || '')
         .map(item => item.trim())
-        .filter(Boolean)
-        .join(', ');
+        .filter(Boolean);
     });
     this.set({
       _items: items,

--- a/properties.schema
+++ b/properties.schema
@@ -75,6 +75,15 @@
             "validators": [],
             "help": "Allow the user to view the 'model answer' if they answer the question incorrectly?"
         },
+        "_canShowCorrectness": {
+            "type": "boolean",
+            "required": false,
+            "default": false,
+            "title": "Display correct answers after submit",
+            "inputType": "Checkbox",
+            "validators": [],
+            "help": "If enabled, this replaces the associated 'model answer' toggle button and a comma separated list of correct options is displayed below the submitted question item."
+        },
         "_canShowFeedback": {
             "type": "boolean",
             "required": true,

--- a/properties.schema
+++ b/properties.schema
@@ -36,6 +36,15 @@
             "default": "The correct answer is",
             "inputType": "Text",
             "validators": [],
+            "help": "If _canShowCorrectness is enabled, this text provides a prefix for the correct option displayed below the submitted question item",
+            "translatable": true
+        },
+        "correctAnswersPrefix": {
+            "type": "string",
+            "required": false,
+            "default": "The correct answers are",
+            "inputType": "Text",
+            "validators": [],
             "help": "If _canShowCorrectness is enabled, this text provides a prefix for the comma separated list of correct options displayed below the submitted question item",
             "translatable": true
         }

--- a/properties.schema
+++ b/properties.schema
@@ -29,6 +29,15 @@
             "validators": [],
             "help": "Text that will be announced by the screen reader when the learner selects the 'hide correct answer' button",
             "translatable": true
+        },
+        "correctAnswerPrefix": {
+            "type": "string",
+            "required": false,
+            "default": "The correct answer is",
+            "inputType": "Text",
+            "validators": [],
+            "help": "If _canShowCorrectness is enabled, this text provides a prefix for the comma separated list of correct options displayed below the submitted question item",
+            "translatable": true
         }
     },
     "properties": {

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -54,6 +54,12 @@
           "description": "Allow the user to view the 'model answer' if they answer the question incorrectly. Defaults to true.",
           "default": true
         },
+        "_canShowCorrectness": {
+          "type": "boolean",
+          "title": "Enable correct answers to display after submit",
+          "description": "If enabled, this replaces the associated 'model answer' toggle button and a comma separated list of correct options is displayed below the submitted question item",
+          "default": false
+        },
         "_canShowFeedback": {
           "type": "boolean",
           "title": "Enable feedback",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -32,8 +32,17 @@
                     "correctAnswerPrefix": {
                       "type": "string",
                       "title": "ARIA prefix for correct answer",
+                      "description": "If _canShowCorrectness is enabled, this text provides a prefix for the correct option displayed below the submitted question item",
+                      "default": "The correct answer is",
+                      "_adapt": {
+                        "translatable": true
+                      }
+                    },
+                    "correctAnswersPrefix": {
+                      "type": "string",
+                      "title": "ARIA prefix for correct answers",
                       "description": "If _canShowCorrectness is enabled, this text provides a prefix for the comma separated list of correct options displayed below the submitted question item",
-                      "default": "The correct answer is ",
+                      "default": "The correct answers are",
                       "_adapt": {
                         "translatable": true
                       }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -28,6 +28,15 @@
                       "_adapt": {
                         "translatable": true
                       }
+                    },
+                    "correctAnswerPrefix": {
+                      "type": "string",
+                      "title": "ARIA prefix for correct answer",
+                      "description": "If _canShowCorrectness is enabled, this text provides a prefix for the comma separated list of correct options displayed below the submitted question item",
+                      "default": "The correct answer is ",
+                      "_adapt": {
+                        "translatable": true
+                      }
                     }
                   }
                 }

--- a/templates/matching.jsx
+++ b/templates/matching.jsx
@@ -22,6 +22,7 @@ export default function Matching(props) {
   const displayAsCorrect = (_isInteractionComplete && (_isCorrectAnswerShown || _isCorrect));
 
   const correctAnswerPrefix = _globals?._components?._matching?.correctAnswerPrefix || '';
+  const correctAnswersPrefix = _globals?._components?._matching?.correctAnswersPrefix || '';
 
   return (
     <div className="component__inner matching__inner">
@@ -47,6 +48,8 @@ export default function Matching(props) {
         }, index) => {
           const activeOption = _options.find(option => (option._itemIndex === _index) && option._isActive);
           const displayItemAsCorrect = (!_isEnabled && _shouldShowMarking && (_isCorrectAnswerShown || activeOption?._shouldBeSelected));
+          const hasMultipleCorrectAnswers = _correctAnswers.length > 1;
+
           return (
             <div key={_index} className={classes([
               'matching-item',
@@ -83,7 +86,7 @@ export default function Matching(props) {
                 key={`answer-${_index}`}
                 className="matching-item__answer-container"
                 dangerouslySetInnerHTML={{
-                  __html: (_isInteractionComplete && correctAnswerPrefix + _correctAnswers) || '&nbsp;'
+                  __html: (_isInteractionComplete && (hasMultipleCorrectAnswers ? correctAnswersPrefix.join(' ') : correctAnswerPrefix.join(' ')) + (hasMultipleCorrectAnswers ? _correctAnswers.join(', ') : _correctAnswers)) || '&nbsp;'
                 }}>
               </div>
               }

--- a/templates/matching.jsx
+++ b/templates/matching.jsx
@@ -8,6 +8,7 @@ export default function Matching(props) {
     _isInteractionComplete,
     _isCorrect,
     _shouldShowMarking,
+    _canShowCorrectness,
     _isCorrectAnswerShown,
     _items,
     _options,
@@ -39,7 +40,8 @@ export default function Matching(props) {
 
         {_items.map(({
           text,
-          _index
+          _index,
+          _correctAnswers
         }, index) => {
           const activeOption = _options.find(option => (option._itemIndex === _index) && option._isActive);
           const displayItemAsCorrect = (!_isEnabled && _shouldShowMarking && (_isCorrectAnswerShown || activeOption?._shouldBeSelected));
@@ -73,6 +75,16 @@ export default function Matching(props) {
                 </div>
 
               </div>
+
+              {_canShowCorrectness &&
+              <div
+                key={`answer-${_index}`}
+                className="matching-item__answer-container"
+                dangerouslySetInnerHTML={{
+                  __html: (_isInteractionComplete && _canShowCorrectness && _correctAnswers) || '&nbsp;'
+                }}>
+              </div>
+              }
 
             </div>
           );

--- a/templates/matching.jsx
+++ b/templates/matching.jsx
@@ -21,8 +21,8 @@ export default function Matching(props) {
 
   const displayAsCorrect = (_isInteractionComplete && (_isCorrectAnswerShown || _isCorrect));
 
-  const correctAnswerPrefix = _globals?._components?._matching?.correctAnswerPrefix || '';
-  const correctAnswersPrefix = _globals?._components?._matching?.correctAnswersPrefix || '';
+  const correctAnswerPrefix = _globals?._components?._matching?.correctAnswerPrefix + ' ' || '';
+  const correctAnswersPrefix = _globals?._components?._matching?.correctAnswersPrefix + ' ' || '';
 
   return (
     <div className="component__inner matching__inner">
@@ -86,7 +86,7 @@ export default function Matching(props) {
                 key={`answer-${_index}`}
                 className="matching-item__answer-container"
                 dangerouslySetInnerHTML={{
-                  __html: (_isInteractionComplete && (hasMultipleCorrectAnswers ? (correctAnswersPrefix && correctAnswersPrefix + ' ') : (correctAnswerPrefix && correctAnswerPrefix + ' ')) + (hasMultipleCorrectAnswers ? _correctAnswers.join(', ') : _correctAnswers)) || '&nbsp;'
+                  __html: (_isInteractionComplete && (hasMultipleCorrectAnswers ? correctAnswersPrefix : correctAnswerPrefix) + (hasMultipleCorrectAnswers ? _correctAnswers.join(', ') : _correctAnswers)) || '&nbsp;'
                 }}>
               </div>
               }

--- a/templates/matching.jsx
+++ b/templates/matching.jsx
@@ -81,7 +81,7 @@ export default function Matching(props) {
                 key={`answer-${_index}`}
                 className="matching-item__answer-container"
                 dangerouslySetInnerHTML={{
-                  __html: (_isInteractionComplete && _canShowCorrectness && _correctAnswers) || '&nbsp;'
+                  __html: (_isInteractionComplete && _correctAnswers) || '&nbsp;'
                 }}>
               </div>
               }

--- a/templates/matching.jsx
+++ b/templates/matching.jsx
@@ -86,7 +86,7 @@ export default function Matching(props) {
                 key={`answer-${_index}`}
                 className="matching-item__answer-container"
                 dangerouslySetInnerHTML={{
-                  __html: (_isInteractionComplete && (hasMultipleCorrectAnswers ? correctAnswersPrefix : correctAnswerPrefix) + (hasMultipleCorrectAnswers ? _correctAnswers.join(', ') : _correctAnswers)) || '&nbsp;'
+                  __html: (_isInteractionComplete && (hasMultipleCorrectAnswers ? correctAnswersPrefix : correctAnswerPrefix) + _correctAnswers.join(', ')) || '&nbsp;'
                 }}>
               </div>
               }

--- a/templates/matching.jsx
+++ b/templates/matching.jsx
@@ -21,6 +21,8 @@ export default function Matching(props) {
 
   const displayAsCorrect = (_isInteractionComplete && (_isCorrectAnswerShown || _isCorrect));
 
+  const correctAnswerPrefix = _globals?._components?._matching?.correctAnswerPrefix || '';
+
   return (
     <div className="component__inner matching__inner">
 
@@ -81,7 +83,7 @@ export default function Matching(props) {
                 key={`answer-${_index}`}
                 className="matching-item__answer-container"
                 dangerouslySetInnerHTML={{
-                  __html: (_isInteractionComplete && _correctAnswers) || '&nbsp;'
+                  __html: (_isInteractionComplete && correctAnswerPrefix + _correctAnswers) || '&nbsp;'
                 }}>
               </div>
               }

--- a/templates/matching.jsx
+++ b/templates/matching.jsx
@@ -86,7 +86,7 @@ export default function Matching(props) {
                 key={`answer-${_index}`}
                 className="matching-item__answer-container"
                 dangerouslySetInnerHTML={{
-                  __html: (_isInteractionComplete && (hasMultipleCorrectAnswers ? correctAnswersPrefix.join(' ') : correctAnswerPrefix.join(' ')) + (hasMultipleCorrectAnswers ? _correctAnswers.join(', ') : _correctAnswers)) || '&nbsp;'
+                  __html: (_isInteractionComplete && (hasMultipleCorrectAnswers ? (correctAnswersPrefix && correctAnswersPrefix + ' ') : (correctAnswerPrefix && correctAnswerPrefix + ' ')) + (hasMultipleCorrectAnswers ? _correctAnswers.join(', ') : _correctAnswers)) || '&nbsp;'
                 }}>
               </div>
               }


### PR DESCRIPTION
part of https://github.com/adaptlearning/adapt_framework/issues/3597

Allows option `_canShowCorrectness` instead of  `_canShowModelAnswer`, to replace the associated toggle button and display correctness directly on the component.

### New
* Added support for `_canShowCorrectness`
* Show a comma separated list of correct options when `_canShowCorrectness true`
* `.show-correctness` widget class appended for consistency with other question components. Note, there's no associated styling currently.
* Default prefix text added for the correct options. `correctAnswerPrefix` and `correctAnswersPrefix` added to support both single and multiple correct answers. For now this just exists in course `_globals` but could later add a component level override if needed. Or move these to Core if shared across question components. Prefix is optional.

![matching_with_updated_prefixes](https://github.com/user-attachments/assets/7acca27c-0c5f-40d2-865c-5673bbcefb96)

#### Requires
ref https://github.com/adaptlearning/adapt-contrib-core/pull/582